### PR TITLE
Remove config creation and rename cvar to sv_crashcfg

### DIFF
--- a/scripts/game_master/map_transitions.script
+++ b/scripts/game_master/map_transitions.script
@@ -50,8 +50,6 @@
 	{
 		callexternal players ext_setspawn GM_DEST_TRANS
 	}
-
-	callevent write_crashcfg DEST_MAP
 	
 	local L_CMD "echo Changelevel: " DEST_MAP
 	servercmd L_CMD //Report changelevel to server
@@ -85,19 +83,6 @@
 	callevent 5.0 delay_changelevel
 }
 
-{ write_crashcfg //<mapname> //Writes to the crashed cfg file
-
-	local L_CFG_NAME $func(func_crashcfg_name)
-	erasefile L_CFG_NAME
-	local L_STR "map " PARAM1 " /" "/" "written from MSR" //Double slash was creating a commend and eating it lol
-	writeline L_CFG_NAME L_STR
-}
-
-{ reset_server //called from game_master
-
-	callevent write_crashcfg edana
-}
-
 { game_triggered //<map trigger fired>
 	dbg game_triggered PARAM1
 
@@ -123,7 +108,7 @@
 { func_crashcfg_name //returns full crashcfg name
 
 	//Crash file name configuration
-	local L_STR game.cvar.ms_crashcfg
+	local L_STR game.cvar.sv_crashcfg
 	if ( L_STR !contains '.cfg' )
 	{
 		stradd L_STR ".cfg"

--- a/scripts/sv_world_commands.script
+++ b/scripts/sv_world_commands.script
@@ -370,7 +370,7 @@
 	if ( PARAM1 equals 'teststuff' )
 	{
 		infomsg all "literally gonna cry" $get($get(ent_currentplayer,target),index)
-		infomsg all $get(ent_currentplayer,glowcolor) game.cvar.ms_crashcfg
+		infomsg all $get(ent_currentplayer,glowcolor) game.cvar.sv_crashcfg
 	}
 		
 	if ( PARAM1 equals 'listmaps' )


### PR DESCRIPTION
* The creation of the crashed.cfg is now handled in the game code.
* The CVAR is now called ``sv_crashcfg`` since it's now created in the server engine to allow it to be used a launch parameter.