### PR TITLE
Chain lightning and fast swim fix

### DIFF
--- a/scripts/monsters/djinn_lightning.script
+++ b/scripts/monsters/djinn_lightning.script
@@ -164,6 +164,9 @@
 
 { push_targets
 	local CUR_TARGET $get_token(BEAM_TARGET_LIST,game.script.iteration)
+	if $get(CUR_TARGET,name) isnot "Npc" 
+	if $get(CUR_TARGET,name) isnot  "0"
+
 	local TARG_ORG $get(BEAM_TARGET_LIST,origin)
 	local TRACE_LINE $get_traceline(game.monster.origin,TARG_ORG,worldonly)
 	if TRACE_LINE equals TARG_ORG
@@ -199,6 +202,8 @@
 { set_beam
 	local CUR_BEAM_ID $get_token(BEAM_LIST,CUR_BEAM)
 	local CUR_TARGET $get_token(BEAM_TARGET_LIST,game.script.iteration)
+	if $get(CUR_TARGET,name) isnot  "Npc" 
+	if $get(CUR_TARGET,name) isnot  "0" 
 
 	if CUR_BEAM_ID isnot 0
 

--- a/scripts/player/player_animation.script
+++ b/scripts/player/player_animation.script
@@ -34,6 +34,8 @@
 	}
 	else if( L_WATERLEVEL >= 2 ) setvard anim.underwater 1
 
+	if ( anim.underwater ) setstatus add swimming
+
 	gaitframerate 0		//Reset gait framerate
 
 	if( game.monster.anim.type == ANIM_TYPE_WALK ) callevent walk_animate


### PR DESCRIPTION
One of the most prevalent crashes on cleicert was from the djinn trying to push or damage a recently despawned entity. This usually would be a poison cloud. The animation for swimming now works properly when preparing a spell, but there may be a better way to handle it in the script.