### PR TITLE
Update Drops System

### DIFF
--- a/scripts/chests/base_treasurechest.script
+++ b/scripts/chests/base_treasurechest.script
@@ -48,6 +48,14 @@
 	array.create TC_ARTIFACT_CHANCE
 	array.create TC_STORE_GOLDS
 
+	array.create TC_ARTIFACT_GUARANTEED
+
+	array.create DROP_CHANCE_SCALING //base drop chance will be multiplied by these numbers
+	array.add DROP_CHANCE_SCALING 1.5 //if 4 players, check idx 0
+	array.add DROP_CHANCE_SCALING 1 //please always use 1 as base <3
+	array.add DROP_CHANCE_SCALING 0.5 //if 3-2 players, check idx 2 and 3
+	array.add DROP_CHANCE_SCALING 0.25 //if only 1 player, just use base
+
 	//set self adj level on spawn
 	//callevent theeventforselfadj
 }
@@ -130,7 +138,8 @@
 	//Must have at least 1% of highest player to qualify for regular loot
 	//Anything less and they get noob loot
 	
-	callexternal GAME_MASTER gm_find_strongest_reset
+	//callexternal GAME_MASTER gm_find_strongest_reset
+	callexternal GAME_MASTER gm_top_players_reset 1//Redundant? 
 	local L_HIGHEST_DMGPOINTS $get(GAME_MASTER,scriptvar,'STRONGEST_STAT_LEVEL')
 	
 	callexternal CHEST_USER ext_get_dmgpoints
@@ -203,8 +212,14 @@
 { tc_add_artifact //<scriptname> <%chance to drop 1-100>
 
 	setmodelbody 0 1 //using black treasure model
-	array.add TC_ARTIFACT PARAM1
-	array.add TC_ARTIFACT_CHANCE PARAM2
+	if ( PARAM2 >= 100 ) {
+		array.add TC_ARTIFACT_GUARANTEED PARAM1
+	}
+	else 
+	{
+		array.add TC_ARTIFACT PARAM1
+		array.add TC_ARTIFACT_CHANCE PARAM2
+	}
 }
 
 { tc_artifacts //rolls and gives artifacts to winners
@@ -213,69 +228,109 @@
 	setvard GAVE_ARTIFACTS 1
 	if $get_array_amt(TC_ARTIFACT) > 0
 	
-	getplayersarray TC_ARTIFACT_WINNERS
+	//getplayersarray TC_ARTIFACT_WINNERS
 	
-	callexternal GAME_MASTER gm_find_strongest_reset
+	//callexternal GAME_MASTER gm_find_strongest_reset
+	callexternal GAME_MASTER gm_top_players_reset 4
+	
+	setvard TC_ARTIFACT_WINNERS $get(GAME_MASTER,scriptvar,'SORTED_TOP_PLAYERS')
+	
 	setvard TC_HIGHEST_DMGPOINTS $get(GAME_MASTER,scriptvar,'STRONGEST_STAT_LEVEL')
 	setvard TC_ALL_DMGPOINTS 0
 	
-	calleventloop $get_array_amt(TC_ARTIFACT_WINNERS) tc_filter_winner_by_pts
+	array.create GUARANTEED_IDX_ARR
 	
-	calleventloop $get_array_amt(TC_ARTIFACT_WINNERS) tc_filter_winner_by_roll
+	//calleventloop $get_array_amt(TC_ARTIFACT_WINNERS) tc_filter_winner_by_pts
+	calleventloop $get_token_amt(TC_ARTIFACT_WINNERS) tc_filter_winner_by_roll
 }
 
-{ tc_filter_winner_by_pts
+//{ tc_filter_winner_by_pts
+//
+//	if ( game.script.iteration == 0 ) setvard NUM_REMOVED 0
+//		
+//	local L_IDX $math(subtract,game.script.iteration,NUM_REMOVED)
+//	local L_PLAYER_ID $get_token(TC_ARTIFACT_WINNERS,L_IDX)
+//	
+//	callexternal L_PLAYER_ID ext_get_dmgpoints
+//	local L_MY_PTS $get(L_PLAYER_ID,scriptvar,'EXT_DMGPOINTS')
+//	
+//	if ( $math(divide,TC_HIGHEST_DMGPOINTS,100) <= L_MY_PTS )
+//	{
+//		add TC_ALL_DMGPOINTS L_MY_PTS //yayy i can roll
+//	}
+//	else //boo not enough pts...
+//	{
+//		array.del TC_ARTIFACT_WINNERS L_IDX
+//		add NUM_REMOVED 1
+//	}
+//}
 
-	if ( game.script.iteration == 0 ) setvard NUM_REMOVED 0
-		
-	local L_IDX $math(subtract,game.script.iteration,NUM_REMOVED)
-	local L_PLAYER_ID $get_array(TC_ARTIFACT_WINNERS,L_IDX)
+{ give_each_guaranteed_loop
+
+	local L_IDX game.script.iteration
 	
-	callexternal L_PLAYER_ID ext_get_dmgpoints
-	local L_MY_PTS $get(L_PLAYER_ID,scriptvar,'EXT_DMGPOINTS')
-	
-	if ( $math(divide,TC_HIGHEST_DMGPOINTS,100) <= L_MY_PTS )
-	{
-		add TC_ALL_DMGPOINTS L_MY_PTS //yayy i can roll
-	}
-	else //boo not enough pts...
-	{
-		array.del TC_ARTIFACT_WINNERS L_IDX
-		add NUM_REMOVED 1
-	}
+	local L_GUAR_ITEM $get_array(TC_ARTIFACT_GUARANTEED,L_IDX)
+	addstoreitem STORENAME L_GUAR_ITEM 1 0
 }
 
 { tc_filter_winner_by_roll //instantly rolls all artifact chances to avoid roll chance manipulation
-
+	
 	//if ( game.script.iteration == 0 ) setvard NUM_REMOVED 0
 	
 	local L_IDX game.script.iteration //$math(subtract,game.script.iteration,NUM_REMOVED)
-	local L_PLAYER_ID $get_array(TC_ARTIFACT_WINNERS,L_IDX)
+	local L_PLAYER_ID $get_token(TC_ARTIFACT_WINNERS,L_IDX)
+	setvard STORENAME $func(func_make_store_string,L_PLAYER_ID)
+	
+	add TC_ALL_DMGPOINTS $get(L_PLAYER_ID,scriptvar,'EXT_DMGPOINTS')
 	
 	callexternal L_PLAYER_ID ext_get_dmgpoints
-	local L_ROLL_MULTIPLIER $get(L_PLAYER_ID,scriptvar,'EXT_DMGPOINTS') 
-	divide L_ROLL_MULTIPLIER TC_ALL_DMGPOINTS
+
+	local L_POINTS $get(L_PLAYER_ID,scriptvar,'EXT_DMGPOINTS')
+	
+	if L_POINTS >= 1  //Require more than 1k dmgpoints
+	
+	setvard CHEST_USER L_PLAYER_ID
+	callevent tc_make_and_populate_store
+	calleventloop $get_array_amt(TC_ARTIFACT_GUARANTEED) give_each_guaranteed_loop
+	
+	if ( $get_array_amt(TC_ARTIFACT) < 1 )
+	{
+		breakloop
+	}
+	setvard DROP_SCALING_IDX 0
+	
+	if ( $get_token_amt(TC_ARTIFACT_WINNERS) < 4 ) //Less than 4 players, don't give bonus to highest damage scorer
+	{
+		add DROP_SCALING_IDX 1
+	}
+	
+	add DROP_SCALING_IDX L_IDX
+	
+	if ( DROP_SCALING_IDX > $get_array_amt(DROP_CHANCE_SCALING) )
+	{
+		breakloop
+	}
+	
+	local L_ROLL_MULTIPLIER $get_array(DROP_CHANCE_SCALING,DROP_SCALING_IDX)
+	
+	//divide L_ROLL_MULTIPLIER TC_ALL_DMGPOINTS
 	
 	local L_RAND_IDX $get_array_amt(TC_ARTIFACT)
 	subtract L_RAND_IDX 1
 	local L_RAND_IDX $rand(0,L_RAND_IDX)
 	
 	local L_CHANCE $get_array(TC_ARTIFACT_CHANCE,L_RAND_IDX)
-	if ( TC_ALL_DMGPOINTS != 0 )
+	if ( L_CHANCE != 100 ) //100% chance does not get split among players. Everyone gets one.
 	{
-		if ( L_CHANCE != 100 ) //100% chance does not get split among players. Everyone gets one.
-		{
-			multiply L_CHANCE L_ROLL_MULTIPLIER
-		}
+		multiply L_CHANCE L_ROLL_MULTIPLIER
 	}
+	
 	
 	if ( $randf(0,100) <= L_CHANCE ) //winnar! put this item in the chest.
 	{
-		setvard STORENAME $func(func_make_store_string,L_PLAYER_ID)
-		setvard CHEST_USER L_PLAYER_ID
-		callevent tc_make_and_populate_store
-		
 		addstoreitem STORENAME $get_array(TC_ARTIFACT,L_RAND_IDX) 1 0
+		array.del TC_ARTIFACT L_RAND_IDX //Remove the artifact
+		array.del TC_ARTIFACT_CHANCE L_RAND_IDX //Remove associated drop chance
 	}
 }
 

--- a/scripts/chests/base_treasurechest.script
+++ b/scripts/chests/base_treasurechest.script
@@ -238,8 +238,6 @@
 	setvard TC_HIGHEST_DMGPOINTS $get(GAME_MASTER,scriptvar,'STRONGEST_STAT_LEVEL')
 	setvard TC_ALL_DMGPOINTS 0
 	
-	array.create GUARANTEED_IDX_ARR
-	
 	//calleventloop $get_array_amt(TC_ARTIFACT_WINNERS) tc_filter_winner_by_pts
 	calleventloop $get_token_amt(TC_ARTIFACT_WINNERS) tc_filter_winner_by_roll
 }

--- a/scripts/game_master/dmgpoints.script
+++ b/scripts/game_master/dmgpoints.script
@@ -14,6 +14,11 @@
 		}
 	}
 	
+	//setvard POINTS_ILIST '' //create and then empty
+	//token.del POINTS_ILIST 0
+	
+	setvard SORTED_TOP_PLAYERS 'SORTED_TOP_PLAYERS' //same
+	token.del SORTED_TOP_PLAYERS 0
 	//First rand does not include a zero so that the code can never evaluate to 0
 	if ( L_GENERATE_CODE ) setvarg G_DM_CODE $rand(1,9) $rand(0,9) $rand(0,9) $rand(0,9) $rand(0,9) $rand(0,9)
 }
@@ -25,8 +30,7 @@
 	setvard STRONGEST_IDX 0
 	setvard STRONGEST_STAT_LEVEL 0
 	if ( STRONGEST_PLAYER_LIST equals 'STRONGEST_PLAYER_LIST' ) getplayersnb STRONGEST_PLAYER_LIST
-	calleventloop $get_token_amt(STRONGEST_PLAYER_LIST) find_strongest_player_loop
-	setvard THE_CHOSEN_ONE $get_token(STRONGEST_PLAYER_LIST,STRONGEST_IDX)
+	//calleventloop $get_token_amt(STRONGEST_PLAYER_LIST) find_strongest_player_loop
 	setvard THE_CHOSEN_ONE_IDX STRONGEST_IDX
 	token.del PLAYER_LIST STRONGEST_IDX
 	//callevent inform_player //SEP2009 event not used (probably hold over from arti-chest)
@@ -40,7 +44,7 @@
 { find_strongest_player_loop
 
 	local CUR_IDX game.script.iteration
-	local CUR_PLAYER $get_token(STRONGEST_PLAYER_LIST,CUR_IDX)
+	local CUR_PLAYER $get_token(POINTS_ILIST,CUR_IDX)
 	
 	callexternal CUR_PLAYER ext_get_dmgpoints
 	local PLAYER_STAT $get(CUR_PLAYER,scriptvar,'EXT_DMGPOINTS') 
@@ -50,4 +54,51 @@
 		setvard STRONGEST_STAT_LEVEL PLAYER_STAT
 		setvard STRONGEST_IDX CUR_IDX
 	}
+}
+
+{ gm_top_players_reset //PARAM1 loop limit
+	setvard SORTED_TOP_PLAYERS 'SORTED_TOP_PLAYERS'
+	token.del SORTED_TOP_PLAYERS 0
+	callevent gm_find_top_players PARAM1
+}
+
+{ gm_find_top_players //PARAM1 max num of players to return
+
+	setvard STRONGEST_PLAYER_LIST 'STRONGEST_PLAYER_LIST'
+	getplayersnb POINTS_ILIST //Temp until gm_add_map_player works properly
+	
+	setvard LOOP_LIMIT PARAM1
+	local L_DMG_PLAYERS_AMT $get_token_amt(POINTS_ILIST)
+
+	if ( L_DMG_PLAYERS_AMT < LOOP_LIMIT )
+	{
+		setvard LOOP_LIMIT L_DMG_PLAYERS_AMT
+	}
+	if ( STRONGEST_PLAYER_LIST equals 'STRONGEST_PLAYER_LIST' ) getplayersnb STRONGEST_PLAYER_LIST
+	calleventloop LOOP_LIMIT find_top_players_loop
+	setvard THE_CHOSEN_ONE $get_token(STRONGEST_PLAYER_LIST,THE_CHOSEN_ONE_IDX)
+}
+
+{ find_top_players_loop // heavily influenced by the points command of world/server/commands (Sorry!)
+
+	local L_CUR_TOP_IDX game.script.iteration
+	setvard STRONGEST_IDX 0
+	setvard STRONGEST_STAT_LEVEL 0
+
+	//setvard CUR_PLR_ID $get_token(POINTS_ILIST,L_CUR_TOP_IDX)  //Player id
+
+	calleventloop LOOP_LIMIT find_strongest_player_loop 
+	
+	token.add SORTED_TOP_PLAYERS $get_token(POINTS_ILIST,STRONGEST_IDX) //Hopefully a concise enough name
+	
+	token.del POINTS_ILIST STRONGEST_IDX 
+}
+
+{ gm_add_map_player
+	
+	if PARAM1 isnot 'PARAM1'
+	if $get_find_token(POINTS_ILIST,PARAM1) < 0
+
+	//token.add POINTS_ILIST PARAM1 //Figure out why this is broken in future
+
 }

--- a/scripts/player/server/dmgpoints.script
+++ b/scripts/player/server/dmgpoints.script
@@ -16,10 +16,13 @@
 
 	if ( INIT_DMGPOINTS ) exitevent
 	setvard INIT_DMGPOINTS 1
-	
+
 	if ( G_DM_CODE equals $get_quest_data(ent_me,dm) ) //I already have dmgpoints on this map/gauntlet
 	{
-		callevent restore_dmg_points
+		if ( G_DM_CODE isnot 'G_DM_CODE' )
+		{
+			callevent restore_dmg_points
+		}
 	}
 	else
 	{
@@ -112,6 +115,8 @@
 
 		callevent store_dmg_points
 	}
+	getplayer L_PLR_TOKEN $get(ent_me,index)
+	callexternal GAME_MASTER gm_add_map_player L_PLR_TOKEN
 }
 
 //For adding damage points for special events (such as rescuing player from goblin pouncer)


### PR DESCRIPTION
There is still potentially unused code in game_master/dmgpoints.script that could be cleaned up. Need to check for issues before ripping that out, likely at a later date.

In theory, you should be able to call the event `gm_top_players_reset` with a single parameter of the requested number of players, and get `SORTED_TOP_PLAYERS` to get more than just the usual 4 top damagers.

- Updated the gauntlet resume code to not accept basically a null code
- The top 4 players get a chance to roll for artifacts
- Multiple guaranteed and non-guaranteed artifacts can be placed in a single chest
- No longer requires you to have a percent of the total dmgpoints to roll, just require 1,000 
- Increased chance of receiving an artifact when playing with other players, without needing to be the highest damager

